### PR TITLE
Made this mirror match go-audit's official release

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Wikipedia has a pretty good [page](https://en.wikipedia.org/wiki/Syslog) on this
 | **local6 (22)**   | 176      | 177       | 178       | 179     | 180      | 181        | 182       | 183       |
 | **local7 (23)**   | 184      | 185       | 186       | 187     | 188      | 189        | 190       | 191       |
 
+#### I am seeing duplicate entries in syslog!
+
+This is likely because you are running `journald` which is also reading audit events. To disable it you need to disable the functionality in `journald`.
+
+```sh
+sudo systemctl mask systemd-journald-audit.socket
+```
+
 ## Thanks!
 
 To Hardik Juneja, Arun Sori, Aalekh Nigam Aalekhn for the inspiration via https://github.com/mozilla/audit-go

--- a/audit_test.go
+++ b/audit_test.go
@@ -62,7 +62,7 @@ func Test_setRules(t *testing.T) {
 
 	// fail on 0 rules
 	err = setRules(config, func(s string, a ...string) error { return nil })
-	assert.EqualError(t, err, "No audit rules found.")
+	assert.EqualError(t, err, "No audit rules found")
 
 	// failure to set rule
 	r := 0
@@ -326,6 +326,135 @@ func Test_createOutput(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	_, err = os.Stat(path.Join(os.TempDir(), "go-audit.test.log"))
 	assert.Nil(t, err)
+}
+
+func Test_createFilters(t *testing.T) {
+	lb, elb := hookLogger()
+	defer resetLogger()
+
+	// no filters
+	c := viper.New()
+	f, err := createFilters(c)
+	assert.Nil(t, err)
+	assert.Empty(t, f)
+
+	// Bad outer filter value
+	c = viper.New()
+	c.Set("filters", 1)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "Could not parse filters object")
+	assert.Empty(t, f)
+
+	// Bad inner filter value
+	c = viper.New()
+	rf := make([]interface{}, 0)
+	rf = append(rf, "bad filter definition")
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "Could not parse filter 1; 'bad filter definition'")
+	assert.Empty(t, f)
+
+	// Bad message type - string
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"message_type": "bad message type"})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "`message_type` in filter 1 could not be parsed; Value: `bad message type`; Error: strconv.ParseUint: parsing \"bad message type\": invalid syntax")
+	assert.Empty(t, f)
+
+	// Bad message type - unknown
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"message_type": false})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "`message_type` in filter 1 could not be parsed; Value: `false`")
+	assert.Empty(t, f)
+
+	// Bad regex - not string
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"regex": false})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "`regex` in filter 1 could not be parsed; Value: `false`")
+	assert.Empty(t, f)
+
+	// Bad regex - un-parse-able
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"regex": "["})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "`regex` in filter 1 could not be parsed; Value: `[`; Error: error parsing regexp: missing closing ]: `[`")
+	assert.Empty(t, f)
+
+	// Bad syscall - not string or int
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"syscall": []string{}})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "`syscall` in filter 1 could not be parsed; Value: `[]`")
+	assert.Empty(t, f)
+
+	// Missing regex
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"syscall": "1", "message_type": "1"})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "Filter 1 is missing the `regex` entry")
+	assert.Empty(t, f)
+
+	// Missing message_type
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"syscall": "1", "regex": "1"})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "Filter 1 is missing the `message_type` entry")
+	assert.Empty(t, f)
+
+	// Missing message_type
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"message_type": "1", "regex": "1"})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.EqualError(t, err, "Filter 1 is missing the `syscall` entry")
+	assert.Empty(t, f)
+
+	// Good with strings
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"message_type": "1", "regex": "1", "syscall": "1"})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, f)
+	assert.Equal(t, "1", f[0].syscall)
+	assert.Equal(t, uint16(1), f[0].messageType)
+	assert.Equal(t, "1", f[0].regex.String())
+	assert.Empty(t, elb.String())
+	assert.Equal(t, "Ignoring syscall `1` containing message type `1` matching string `1`\n", lb.String())
+
+	// Good with ints
+	lb.Reset()
+	elb.Reset()
+	c = viper.New()
+	rf = make([]interface{}, 0)
+	rf = append(rf, map[interface{}]interface{}{"message_type": 1, "regex": "1", "syscall": 1})
+	c.Set("filters", rf)
+	f, err = createFilters(c)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, f)
+	assert.Equal(t, "1", f[0].syscall)
+	assert.Equal(t, uint16(1), f[0].messageType)
+	assert.Equal(t, "1", f[0].regex.String())
+	assert.Empty(t, elb.String())
+	assert.Equal(t, "Ignoring syscall `1` containing message type `1` matching string `1`\n", lb.String())
 }
 
 func Benchmark_MultiPacketMessage(b *testing.B) {

--- a/client.go
+++ b/client.go
@@ -7,12 +7,14 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"fmt"
 )
 
+// Endianness is an alias for what we assume is the current machine endianness
 var Endianness = binary.LittleEndian
 
 const (
-	//http://lxr.free-electrons.com/source/include/uapi/linux/audit.h#L398
+	// MAX_AUDIT_MESSAGE_LENGTH see http://lxr.free-electrons.com/source/include/uapi/linux/audit.h#L398
 	MAX_AUDIT_MESSAGE_LENGTH = 8970
 )
 
@@ -30,7 +32,7 @@ type AuditStatusPayload struct {
 	BacklogWaitTime uint32
 }
 
-//An alias to give the header a similar name here
+// NetlinkPacket is an alias to give the header a similar name here
 type NetlinkPacket syscall.NlMsghdr
 
 type NetlinkClient struct {
@@ -40,10 +42,11 @@ type NetlinkClient struct {
 	buf     []byte
 }
 
-func NewNetlinkClient(recvSize int) *NetlinkClient {
+// NewNetlinkClient creates a new NetLinkClient and optionally tries to modify the netlink recv buffer
+func NewNetlinkClient(recvSize int) (*NetlinkClient, error) {
 	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_AUDIT)
 	if err != nil {
-		el.Fatalln("Could not create a socket:", err)
+		return nil, fmt.Errorf("Could not create a socket: %s", err)
 	}
 
 	n := &NetlinkClient{
@@ -54,12 +57,14 @@ func NewNetlinkClient(recvSize int) *NetlinkClient {
 
 	if err = syscall.Bind(fd, n.address); err != nil {
 		syscall.Close(fd)
-		el.Fatalln("Could not bind to netlink socket:", err)
+		return nil, fmt.Errorf("Could not bind to netlink socket: %s", err)
 	}
 
 	// Set the buffer size if we were asked
 	if recvSize > 0 {
-		err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, recvSize)
+		if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, recvSize); err != nil {
+			el.Println("Failed to set receive buffer size")
+		}
 	}
 
 	// Print the current receive buffer size
@@ -74,9 +79,10 @@ func NewNetlinkClient(recvSize int) *NetlinkClient {
 		}
 	}()
 
-	return n
+	return n, nil
 }
 
+// Send will send a packet and payload to the netlink socket without waiting for a response
 func (n *NetlinkClient) Send(np *NetlinkPacket, a *AuditStatusPayload) error {
 	//We need to get the length first. This is a bit wasteful, but requests are rare so yolo..
 	buf := new(bytes.Buffer)
@@ -103,6 +109,7 @@ func (n *NetlinkClient) Send(np *NetlinkPacket, a *AuditStatusPayload) error {
 	return nil
 }
 
+// Receive will receive a packet from a netlink socket
 func (n *NetlinkClient) Receive() (*syscall.NetlinkMessage, error) {
 	nlen, _, err := syscall.Recvfrom(n.fd, n.buf, 0)
 	if err != nil {
@@ -127,6 +134,7 @@ func (n *NetlinkClient) Receive() (*syscall.NetlinkMessage, error) {
 	return msg, nil
 }
 
+// KeepConnection re-establishes our connection to the netlink socket
 func (n *NetlinkClient) KeepConnection() {
 	payload := &AuditStatusPayload{
 		Mask:    4,

--- a/client_test.go
+++ b/client_test.go
@@ -91,15 +91,20 @@ func TestNewNetlinkClient(t *testing.T) {
 	lb, elb := hookLogger()
 	defer resetLogger()
 
-	n := NewNetlinkClient(1024)
+	n, err := NewNetlinkClient(1024)
 
-	assert.True(t, (n.fd > 0), "No file descriptor")
-	assert.True(t, (n.address != nil), "Address was nil")
-	assert.Equal(t, uint32(0), n.seq, "Seq should start at 0")
-	assert.True(t, MAX_AUDIT_MESSAGE_LENGTH >= len(n.buf), "Client buffer is too small")
+	assert.Nil(t, err)
+	if n == nil {
+		t.Fatal("Expected a netlink client but had an error instead!")
+	} else {
+		assert.True(t, (n.fd > 0), "No file descriptor")
+		assert.True(t, (n.address != nil), "Address was nil")
+		assert.Equal(t, uint32(0), n.seq, "Seq should start at 0")
+		assert.True(t, MAX_AUDIT_MESSAGE_LENGTH >= len(n.buf), "Client buffer is too small")
 
-	assert.Equal(t, "Socket receive buffer size: ", lb.String()[:28], "Expected some nice log lines")
-	assert.Equal(t, "", elb.String(), "Did not expect any error messages")
+		assert.Equal(t, "Socket receive buffer size: ", lb.String()[:28], "Expected some nice log lines")
+		assert.Equal(t, "", elb.String(), "Did not expect any error messages")
+	}
 }
 
 // Helper to make a client listening on a unix socket

--- a/marshaller.go
+++ b/marshaller.go
@@ -158,7 +158,7 @@ func (a *AuditMarshaller) detectMissing(seq int) {
 		}
 	}
 
-	for missedSeq, _ := range a.missed {
+	for missedSeq := range a.missed {
 		if missedSeq == seq {
 			lag := a.lastSeq - missedSeq
 			if lag > a.worstLag {

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshallerConstants(t *testing.T) {
@@ -122,23 +123,23 @@ func TestAuditMarshaller_completeMessage(t *testing.T) {
 	//TODO: cant test because completeMessage calls exit
 	t.Skip()
 	return
-	lb, elb := hookLogger()
-	m := NewAuditMarshaller(NewAuditWriter(&FailWriter{}, 1), uint16(1300), uint16(1399), false, false, 0, []AuditFilter{})
+	// lb, elb := hookLogger()
+	// m := NewAuditMarshaller(NewAuditWriter(&FailWriter{}, 1), uint16(1300), uint16(1399), false, false, 0, []AuditFilter{})
 
-	m.Consume(&syscall.NetlinkMessage{
-		Header: syscall.NlMsghdr{
-			Len:   uint32(44),
-			Type:  uint16(1300),
-			Flags: uint16(0),
-			Seq:   uint32(0),
-			Pid:   uint32(0),
-		},
-		Data: []byte("audit(10000001:4): hi there"),
-	})
+	// m.Consume(&syscall.NetlinkMessage{
+	// 	Header: syscall.NlMsghdr{
+	// 		Len:   uint32(44),
+	// 		Type:  uint16(1300),
+	// 		Flags: uint16(0),
+	// 		Seq:   uint32(0),
+	// 		Pid:   uint32(0),
+	// 	},
+	// 	Data: []byte("audit(10000001:4): hi there"),
+	// })
 
-	m.completeMessage(4)
-	assert.Equal(t, "!", lb.String())
-	assert.Equal(t, "!", elb.String())
+	// m.completeMessage(4)
+	// assert.Equal(t, "!", lb.String())
+	// assert.Equal(t, "!", elb.String())
 }
 
 func new1320(seq string) *syscall.NetlinkMessage {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,6 +256,7 @@
 		},
 		{
 			"checksumSHA1": "93uHIq25lffEKY47PV8dBPD+XuQ=",
+			"origin": "github.com/fsnotify/fsnotify",
 			"path": "gopkg.in/fsnotify.v1",
 			"revision": "a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb",
 			"revisionTime": "2016-06-29T01:11:04Z"


### PR DESCRIPTION
More importently, vendor/vendor.json is modified to account for
changes in fsnotify. This won't build otherwise

* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/go-audit/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/go-audit/blob/master/CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

> e.g. New functionality for producing whatsits.

#### Related Issues

> e.g. Fixes #206 and closes #230

#### Test strategy

> e.g. Add tests around whatsit production.
